### PR TITLE
Add annotations for MainActivity and RestaskApplication

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,8 +62,8 @@ dependencies {
     implementation(libs.androidx.room.ktx)
 
     // Hilt-Dependency Injection
-    implementation("com.google.dagger:hilt-android:2.56.2")
-    ksp("com.google.dagger:hilt-android-compiler:2.56.2")
+    implementation(libs.hilt.android)
+    ksp(libs.hilt.android.compiler)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application
+        android:name=".RetaskApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/example/retask/MainActivity.kt
+++ b/app/src/main/java/com/example/retask/MainActivity.kt
@@ -12,7 +12,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.example.retask.ui.theme.RetaskTheme
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/example/retask/RetaskApplication.kt
+++ b/app/src/main/java/com/example/retask/RetaskApplication.kt
@@ -1,0 +1,2 @@
+package com.example.retask
+

--- a/app/src/main/java/com/example/retask/RetaskApplication.kt
+++ b/app/src/main/java/com/example/retask/RetaskApplication.kt
@@ -1,2 +1,7 @@
 package com.example.retask
 
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class RetaskApplication : Application()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.11.1"
+hiltAndroid = "2.56.2"
 kotlin = "2.0.21"
 coreKtx = "1.16.0"
 junit = "4.13.2"
@@ -15,6 +16,8 @@ androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = 
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "roomVersion" }
 androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "roomVersion" }
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "roomVersion" }
+hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hiltAndroid" }
+hilt-android-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hiltAndroid" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }


### PR DESCRIPTION
# What does this PR do?

Adds annotations for MainActivity and RetaskApplication

# Why it is needed?

Adds entry point for `Hilt Dependency Injection` into `Retask` app.

# How was it implemented?

Added `@HiltAndroidApp` above `RetaskApplication` and  `@AndroidEntryPoint` annotation above `MainActivity`. Then added `.RetaskApplication` in `AndroidManifest.xml` file.